### PR TITLE
Fix toggle modes in timers 0 and 2. Fixes #7.

### DIFF
--- a/src/data/atmega328p/timer0.ts
+++ b/src/data/atmega328p/timer0.ts
@@ -29,7 +29,7 @@ WGM0	WGM02	WGM01	WGM00	timerMode	topValue	updateOcrMoment	setTovMoment
 7	1	1	1	FPWM	OCR0A	TOP	TOP
   `),
   tsv(`
-COM0A	COM0A0	COM0A1	timerMode	CompareOutputModeA	WGM02	CompareOutputModeB
+COM0A	COM0A1	COM0A0	timerMode	CompareOutputModeA	WGM02	CompareOutputModeB
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear
@@ -48,7 +48,7 @@ COM0A	COM0A0	COM0A1	timerMode	CompareOutputModeA	WGM02	CompareOutputModeB
 3	1	1	PCPWM	set-up, clear-down
 `),
   tsv(`
-COM0B	COM0B0	COM0B1	timerMode	CompareOutputModeB
+COM0B	COM0B1	COM0B0	timerMode	CompareOutputModeB
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear

--- a/src/data/atmega328p/timer2.ts
+++ b/src/data/atmega328p/timer2.ts
@@ -29,7 +29,7 @@ WGM2	WGM22	WGM21	WGM20	timerMode	topValue	updateOcrMoment	setTovMoment
 7	1	1	1	FPWM	OCR2A	TOP	TOP
   `),
   tsv(`
-COM2A	COM2A0	COM2A1	timerMode	CompareOutputModeA
+COM2A	COM2A1	COM2A0	timerMode	CompareOutputModeA
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear
@@ -48,7 +48,7 @@ COM2A	COM2A0	COM2A1	timerMode	CompareOutputModeA
 3	1	1	PCPWM	set-up, clear-down
 `),
   tsv(`
-COM2B	COM2B0	COM2B1	timerMode	CompareOutputModeB
+COM2B	COM2B1	COM2B0	timerMode	CompareOutputModeB
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear

--- a/src/data/lgt328p/timer0.ts
+++ b/src/data/lgt328p/timer0.ts
@@ -29,7 +29,7 @@ WGM0	WGM02	WGM01	WGM00	timerMode	topValue	updateOcrMoment	setTovMoment
 7	1	1	1	FPWM	OCR0A	TOP	TOP
 `),
   tsv(`
-COM0A	COM0A0	COM0A1	timerMode	CompareOutputModeA	WGM02	CompareOutputModeB
+COM0A	COM0A1	COM0A0	timerMode	CompareOutputModeA	WGM02	CompareOutputModeB
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear
@@ -48,7 +48,7 @@ COM0A	COM0A0	COM0A1	timerMode	CompareOutputModeA	WGM02	CompareOutputModeB
 3	1	1	PCPWM	set-up, clear-down
 `),
   tsv(`
-COM0B	COM0B0	COM0B1	timerMode	CompareOutputModeB
+COM0B	COM0B1	COM0B0	timerMode	CompareOutputModeB
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear

--- a/src/data/lgt328p/timer2.ts
+++ b/src/data/lgt328p/timer2.ts
@@ -30,7 +30,7 @@ WGM2	WGM22	WGM21	WGM20	timerMode	topValue	updateOcrMoment	setTovMoment
   `),
 
   tsv(`
-COM2A	COM2A0	COM2A1	timerMode	CompareOutputModeA
+COM2A	COM2A1	COM2A0	timerMode	CompareOutputModeA
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear
@@ -49,7 +49,7 @@ COM2A	COM2A0	COM2A1	timerMode	CompareOutputModeA
 3	1	1	PCPWM	set-up, clear-down
 `),
   tsv(`
-COM2B	COM2B0	COM2B1	timerMode	CompareOutputModeB
+COM2B	COM2B1	COM2B0	timerMode	CompareOutputModeB
 0	0	0	Normal	disconnect
 1	0	1	Normal	toggle
 2	1	0	Normal	clear


### PR DESCRIPTION
The column names for COM0A0 and COM0A1 were swapped (same for COM2 and port B)